### PR TITLE
Refresh year on rebuild

### DIFF
--- a/build.js
+++ b/build.js
@@ -32,7 +32,7 @@ async function renderPages() {
 	const data = {
 		releases: await getReleases(),
 		posts: await getPosts(),
-    currentYear: new Date().getUTCFullYear(),
+		currentYear: new Date().getUTCFullYear(),
 		formatDate: () => (date, render) => (new Date(Date.parse(render(date)))).toLocaleDateString('en-GB', { year: 'numeric', month: 'numeric', day: 'numeric' }),
 	};
 	const templates = {

--- a/build.js
+++ b/build.js
@@ -32,6 +32,7 @@ async function renderPages() {
 	const data = {
 		releases: await getReleases(),
 		posts: await getPosts(),
+    currentYear: new Date().getUTCFullYear(),
 		formatDate: () => (date, render) => (new Date(Date.parse(render(date)))).toLocaleDateString('en-GB', { year: 'numeric', month: 'numeric', day: 'numeric' }),
 	};
 	const templates = {

--- a/templates/includes/footer.mustache
+++ b/templates/includes/footer.mustache
@@ -1,3 +1,3 @@
 <footer id="footer" class="site-footer">
-	<p>© 2021-2024 CorsixTH</p>
+	<p>© 2021-{{currentYear}} CorsixTH</p>
 </footer>


### PR DESCRIPTION
Instead of manually updating the year (as we're on 2024), grab year when we rebuild the website.