### PR TITLE
Add 0.70.0 fan video

### DIFF
--- a/templates/pages/media.mustache
+++ b/templates/pages/media.mustache
@@ -27,7 +27,7 @@
 	<section>
 		<h2>Historical release videos</h2>
 		<figure class="video">
-			<iframe width="500" height="375" src="https://www.youtube.com/watch?v=Ew9oEFV8Yd0?feature=oembed" allowfullscreen></iframe>
+			<iframe width="500" height="375" src="https://www.youtube.com/embed/Ew9oEFV8Yd0?feature=oembed" allowfullscreen></iframe>
 			<figcaption>CorsixTH 0.70.0 Fan Video by <a href="https://www.youtube.com/@MasterHellish">Master Hellish</a></figcaption>
 		</figure>
 		<figure class="video">

--- a/templates/pages/media.mustache
+++ b/templates/pages/media.mustache
@@ -27,6 +27,10 @@
 	<section>
 		<h2>Historical release videos</h2>
 		<figure class="video">
+			<iframe width="500" height="375" src="https://www.youtube.com/watch?v=Ew9oEFV8Yd0?feature=oembed" allowfullscreen></iframe>
+			<figcaption>CorsixTH 0.70.0 Fan Video by <a href="https://www.youtube.com/@MasterHellish">Master Hellish</a></figcaption>
+		</figure>
+		<figure class="video">
 			<iframe width="500" height="375" src="https://www.youtube.com/embed/rSN1p247J74?feature=oembed" allowfullscreen></iframe>
 			<figcaption>CorsixTH 0.60</figcaption>
 		</figure>


### PR DESCRIPTION
Add the fan video for Master Hellish we have permission to add to the site.

I'm not sure if a future todo may be implementing collapsible sections for each video to reduce its total scroll length.

<details>
<summary>E.g.</summary>
Like this in Github Markdown
</details>

I should have also used tabs this time instead of spaces.