### PR TITLE
Put release videos in details tags

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -82,7 +82,9 @@ ul,
 li,
 figure,
 figcaption,
-pre
+pre,
+details,
+summary
 {
 	margin: 0;
 	padding: 0;
@@ -532,6 +534,42 @@ iframe
 	background-color: #eee;
 	font: 1em/1em monospace;
 	overflow-x: auto;
+}
+
+.content details {
+	margin-bottom: 0.5em;
+	border: 1px solid rgba(0, 161, 119, 0.6);
+	border-radius: 0.4em;
+}
+
+.content details:hover,
+.content details:focus {
+	border: 1px solid #00a177;
+}
+
+.content details summary,
+.content details[open]::details-content {
+	padding: 0.5em 1em;
+}
+
+.content details summary {
+	position: relative;
+	cursor: pointer;
+}
+
+.content details summary::marker {
+	list-style: none;
+	content: '';
+}
+
+.content details summary::after {
+	position: absolute;
+	right: 1em;
+	content: '+';
+}
+
+.content details[open] summary::after {
+	content: '−';
 }
 
 .content a

--- a/templates/pages/media.mustache
+++ b/templates/pages/media.mustache
@@ -28,65 +28,86 @@
 	</section>
 	<section>
 		<h2>Historical release videos</h2>
-		<figure class="video">
-			<iframe width="500" height="375" src="https://www.youtube.com/embed/Ew9oEFV8Yd0?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH 0.70.0 Fan Video by <a href="https://www.youtube.com/@MasterHellish">Master Hellish</a></figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="375" src="https://www.youtube.com/embed/rSN1p247J74?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH 0.60</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="375" src="https://www.youtube.com/embed/6-oZjCtyeko?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH 0.20</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/ElKXm65W2qg?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH 0.01</figcaption>
-		</figure>
-		<figure>
-			<iframe width="500" height="375" src="https://www.youtube.com/embed/ILu-Wb8YHR0?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Beta6</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/4OvNZjoe_JE?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Beta5</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/NE0E_KzSiBc?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Beta4</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/QOG4ySb8z9U?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Beta3</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/yPodUV8ZrP0?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Beta2</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/X8-DJccLRy0?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Playable Beta 1</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/TdIojoYX59k?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Video 4</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/uxtdPgy3Vu8?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Video 3</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="281" src="https://www.youtube.com/embed/AmgYDUhrb1k?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH Video 2</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="375" src="https://www.youtube.com/embed/PpvOKKnUrs8?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH</figcaption>
-		</figure>
-		<figure class="video">
-			<iframe width="500" height="375" src="https://www.youtube.com/embed/83ACmPn8F0E?feature=oembed" allowfullscreen></iframe>
-			<figcaption>CorsixTH</figcaption>
-		</figure>
+		<details>
+			<summary>CorsixTH 0.70</summary>
+			<figure class="video">
+				<iframe width="500" height="375" src="https://www.youtube.com/embed/Ew9oEFV8Yd0?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH 0.70.0 Fan Video by <a href="https://www.youtube.com/@MasterHellish">Master Hellish</a></figcaption>
+			</figure>
+		</details>
+		<details>
+			<summary>CorsixTH 0.60</summary>
+			<figure class="video">
+				<iframe width="500" height="375" src="https://www.youtube.com/embed/rSN1p247J74?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH 0.60</figcaption>
+			</figure>
+		</details>
+		<details>
+			<summary>CorsixTH 0.20</summary>
+			<figure class="video">
+				<iframe width="500" height="375" src="https://www.youtube.com/embed/6-oZjCtyeko?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH 0.20</figcaption>
+			</figure>
+		</details>
+		<details>
+			<summary>CorsixTH 0.11</summary>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/ElKXm65W2qg?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH 0.11</figcaption>
+			</figure>
+		</details>
+		<details>
+			<summary>CorsixTH 0.01</summary>
+			<figure>
+				<iframe width="500" height="375" src="https://www.youtube.com/embed/ILu-Wb8YHR0?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH 0.01</figcaption>
+			</figure>
+		</details>
+		<details>
+			<summary>CorsixTH Betas</summary>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/4OvNZjoe_JE?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH Beta6</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/NE0E_KzSiBc?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH Beta5</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/QOG4ySb8z9U?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH Beta4</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/yPodUV8ZrP0?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH Beta3</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/X8-DJccLRy0?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH Beta2</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/TdIojoYX59k?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH Playable Beta 1</figcaption>
+			</figure>
+		</details>
+		<details>
+			<summary>CorsixTH early snapshots</summary>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/uxtdPgy3Vu8?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH SVN Snapshot November 25th 2009</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="281" src="https://www.youtube.com/embed/AmgYDUhrb1k?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH SVN Snapshot September 12th 2009</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="375" src="https://www.youtube.com/embed/PpvOKKnUrs8?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH SVN Snapshot September 2nd 2009</figcaption>
+			</figure>
+			<figure class="video">
+				<iframe width="500" height="375" src="https://www.youtube.com/embed/83ACmPn8F0E?feature=oembed" allowfullscreen></iframe>
+				<figcaption>CorsixTH SVN Snapshot July 24th 2009</figcaption>
+			</figure>
+		</details>
 	</section>
 </main>


### PR DESCRIPTION
Following @lewri suggestion, put release videos in details tags in order to reduce the page height:

<img width="1920" height="1200" alt="screenshot" src="https://github.com/user-attachments/assets/97be1001-4e1a-4319-9a09-37d090426e87" />

I kept the styling quite basic, and I grouped beta videos and early snapshot videos in their own categories.

Let me know if you want something to be changed!